### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RimSage
 
 [![MCP Server](https://badge.mcpx.dev?type=server)](https://modelcontextprotocol.io/introduction) [![bun](https://img.shields.io/badge/Bun-%23000000.svg?style=flat&logo=bun)](https://bun.com/) [![ripgrep](https://img.shields.io/badge/ripgrep-%23000000.svg?style=flat&logo=rust)](https://github.com/BurntSushi/ripgrep)
+[![MCP status](https://mcpvitals.com/badge/05b5aba5ce.svg)](https://mcpvitals.com/status/05b5aba5ce)
 
 An MCP server that provides RimWorld source code search and browsing capabilities.
 


### PR DESCRIPTION
Hi — RimSage runs on your own domain at `mcp.rimsage.com`, so if it ever stops answering the README won't show it. This adds a badge that checks the real MCP handshake every few minutes and links to a public uptime page.

Healthy with 6 tools currently. One line, plain SVG, no tracking — close it if you'd rather not.

---
*Disclosure: I build MCP Vitals, the service behind this badge — so I have an interest here. I also used an AI assistant to help prepare this PR. The check is real and reproducible without me: `npx @mcpvitals/cli check <your-endpoint>`. Close it freely if it isn't a fit.*